### PR TITLE
remove GetMapInfo from EventRecordCallback in CallBacks.c

### DIFF
--- a/src/CallBacks.c
+++ b/src/CallBacks.c
@@ -44,7 +44,7 @@ void
 WINAPI
 EventRecordCallback(PEVENT_RECORD EventRecord)
 {
-    PEVENT_MAP_INFO EventMapInfo = NULL;
+    //PEVENT_MAP_INFO EventMapInfo = NULL;
     PBYTE EndOfUserData = (PBYTE)EventRecord->UserData + EventRecord->UserDataLength;
     PBYTE UserData = (PBYTE)EventRecord->UserData;
     ULONG FormattedDataSize = 0;
@@ -93,15 +93,15 @@ EventRecordCallback(PEVENT_RECORD EventRecord)
             wprintf(L"%ls:",
                 (PWCHAR)((PBYTE)(EventInfo) +EventInfo->EventPropertyInfoArray[i].NameOffset));
 
-            GetMapInfo(
-                EventRecord,
-                (PWCHAR)((PBYTE)(EventInfo) +EventInfo->EventPropertyInfoArray[i].nonStructType.MapNameOffset),
-                EventInfo->DecodingSource,
-                &EventMapInfo);
+            //GetMapInfo(
+            //    EventRecord,
+            //    (PWCHAR)((PBYTE)(EventInfo) +EventInfo->EventPropertyInfoArray[i].nonStructType.MapNameOffset),
+            //    EventInfo->DecodingSource,
+            //    &EventMapInfo);
 
             result = TdhFormatProperty(
                 EventInfo,
-                EventMapInfo,
+                NULL, // EventMapInfo
                 sizeof(PVOID),
                 EventInfo->EventPropertyInfoArray[i].nonStructType.InType,
                 EventInfo->EventPropertyInfoArray[i].nonStructType.OutType,
@@ -116,7 +116,7 @@ EventRecordCallback(PEVENT_RECORD EventRecord)
 
             result = TdhFormatProperty(
                 EventInfo,
-                EventMapInfo,
+                NULL, // EventMapInfo
                 sizeof(PVOID),
                 EventInfo->EventPropertyInfoArray[i].nonStructType.InType,
                 EventInfo->EventPropertyInfoArray[i].nonStructType.OutType,
@@ -138,7 +138,7 @@ EventRecordCallback(PEVENT_RECORD EventRecord)
     // Cleanup
     wprintf(L"\n");
     RtlFreeHeap(HeapHandle, 0, EventInfo);
-    RtlFreeHeap(HeapHandle, 0, EventMapInfo);
+    //RtlFreeHeap(HeapHandle, 0, EventMapInfo);
     RtlFreeHeap(HeapHandle, 0, FormattedData);
 }
 

--- a/src/CallBacks.c
+++ b/src/CallBacks.c
@@ -23,19 +23,19 @@ WINAPI
 GetMapInfo(PEVENT_RECORD EventRecord,
            PWCHAR MapName,
            ULONG DecodingSource,
-           PEVENT_MAP_INFO EventMapInfo)
+           PEVENT_MAP_INFO* EventMapInfo)
 {
     ULONG MapSize = 0;
     HANDLE HeapHandle = GetProcessHeap();
 
-    ULONG result = TdhGetEventMapInformation(EventRecord, MapName, EventMapInfo, &MapSize);
-    EventMapInfo = RtlAllocateHeap(HeapHandle, HEAP_ZERO_MEMORY, MapSize);
-    result = TdhGetEventMapInformation(EventRecord, MapName, EventMapInfo, &MapSize);
+    ULONG result = TdhGetEventMapInformation(EventRecord, MapName, *EventMapInfo, &MapSize);
+    *EventMapInfo = RtlAllocateHeap(HeapHandle, HEAP_ZERO_MEMORY, MapSize);
+    result = TdhGetEventMapInformation(EventRecord, MapName, *EventMapInfo, &MapSize);
 
     if (result == ERROR_SUCCESS)
     {
         if (DecodingSource == DecodingSourceXMLFile)
-            RemoveTrailingSpace(EventMapInfo);
+            RemoveTrailingSpace(*EventMapInfo);
     }
 }
 
@@ -97,7 +97,7 @@ EventRecordCallback(PEVENT_RECORD EventRecord)
                 EventRecord,
                 (PWCHAR)((PBYTE)(EventInfo) +EventInfo->EventPropertyInfoArray[i].nonStructType.MapNameOffset),
                 EventInfo->DecodingSource,
-                EventMapInfo);
+                &EventMapInfo);
 
             result = TdhFormatProperty(
                 EventInfo,

--- a/src/SecHost.c
+++ b/src/SecHost.c
@@ -38,7 +38,7 @@ XYZstartTraceW(PTRACEHANDLE TraceHandle,
                PEVENT_TRACE_PROPERTIES_V2 Properties)
 {
     ULONG FilterDescCount, ReturnedLength, LastError;
-    ULONG InstnaceNameLength = INFINITE, LogFileNameLength = INFINITE, BufferSize = 0;
+    ULONG InstanceNameLength = INFINITE, LogFileNameLength = INFINITE, BufferSize = 0;
     BOOLEAN IsLogFilePresent;
     PEVENT_FILTER_DESCRIPTOR FilterDesc = NULL;
     PWSTR LogFileName = NULL;
@@ -71,9 +71,9 @@ XYZstartTraceW(PTRACEHANDLE TraceHandle,
 
     do
     {
-        ++InstnaceNameLength;
-    } while (InstanceName[InstnaceNameLength]);
-    BufferSize = ReturnedLength + (sizeof (wchar_t) * (InstnaceNameLength + 1));
+        ++InstanceNameLength;
+    } while (InstanceName[InstanceNameLength]);
+    BufferSize = ReturnedLength + (sizeof (wchar_t) * (InstanceNameLength + 1));
 
     if (Properties->LogFileNameOffset <= 0)
     {
@@ -143,7 +143,7 @@ XYZstartTraceW(PTRACEHANDLE TraceHandle,
             LogFileNameOffset = Properties->Wnode.BufferSize;
         Diff = LogFileNameOffset - LoggerNameOffset;
 
-        if (sizeof (wchar_t) * (InstnaceNameLength + 1) <= Diff)
+        if (sizeof (wchar_t) * (InstanceNameLength + 1) <= Diff)
             StringCbCopyW((PWSTR)((PBYTE)Properties + LoggerNameOffset), Diff, InstanceName);
 
         if (LogFileNameOffset > LoggerNameOffset)
@@ -168,7 +168,7 @@ XYZcontrolTraceW(TRACEHANDLE TraceHandle,
                  ULONG ControlCode)
 {
     ULONG FilterDescCount, ReturnedLength, LastError;
-    ULONG InstnaceNameLength = INFINITE, LogFileNameLength = INFINITE, BufferSize = 0;
+    ULONG InstanceNameLength = INFINITE, LogFileNameLength = INFINITE, BufferSize = 0;
     BOOLEAN IsLogFilePresent;
     PEVENT_FILTER_DESCRIPTOR FilterDesc = NULL;
     PWSTR LogFileName = NULL;
@@ -206,12 +206,12 @@ XYZcontrolTraceW(TRACEHANDLE TraceHandle,
 
         do
         {
-            ++InstnaceNameLength;
-        } while (InstanceName[InstnaceNameLength]);
-        BufferSize = ReturnedLength + (sizeof (wchar_t) * (InstnaceNameLength + 1));
+            ++InstanceNameLength;
+        } while (InstanceName[InstanceNameLength]);
+        BufferSize = ReturnedLength + (sizeof (wchar_t) * (InstanceNameLength + 1));
     }
     else
-        InstnaceNameLength = 0;
+        InstanceNameLength = 0;
 
     if (Properties->LogFileNameOffset <= 0)
     {
@@ -293,7 +293,7 @@ XYZcontrolTraceW(TRACEHANDLE TraceHandle,
             LogFileNameOffset = Properties->Wnode.BufferSize;
         Diff = LogFileNameOffset - LoggerNameOffset;
 
-        if (sizeof (wchar_t) * (InstnaceNameLength + 1) <= Diff)
+        if (InstanceName && (sizeof (wchar_t) * (InstanceNameLength + 1) <= Diff) )
             StringCbCopyW((PWSTR)((PBYTE)Properties + LoggerNameOffset), Diff, InstanceName);
 
         if (LogFileNameOffset > LoggerNameOffset)


### PR DESCRIPTION
The original `GetMapInfo` will left `EventMapInfo` in the stack of `EventRecordCallback` unchanged.
This fix changes the passing method of `EventMapInfo` from value to pointer.